### PR TITLE
fix: IAsaasPayment interface, split parameter is array of objects

### DIFF
--- a/src/types/AsaasTypes.ts
+++ b/src/types/AsaasTypes.ts
@@ -97,7 +97,7 @@ export interface IAsaasPayment {
   interest?: Fine;
   postalService?: boolean;
   authorizedOnly?: boolean;
-  split?: Split;
+  split?: Split[];
   callback?: Callback;
 }
 


### PR DESCRIPTION
In the AsaaS API, when we create a charge, we can define one or more splits, which is an array of objects.